### PR TITLE
add program id for devnet

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,3 +1,6 @@
+[programs.devnet]
+doorman = "D8bTW1sgKaSki1TBUwxarPySLp3TNVgB2bwRVbbTLYeV"
+
 [programs.localnet]
 doorman = "D8bTW1sgKaSki1TBUwxarPySLp3TNVgB2bwRVbbTLYeV"
 


### PR DESCRIPTION
running "anchor run initialize" does not work in devnet with only a localnet program id defined.
Therefore adding the devnet program id